### PR TITLE
Обновление зависимостей в проекте тестирования

### DIFF
--- a/NetSdrClientAppTests/NetSdrClientAppTests.csproj
+++ b/NetSdrClientAppTests/NetSdrClientAppTests.csproj
@@ -11,7 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />


### PR DESCRIPTION
Удалена зависимость `coverlet.collector` версии `6.0.0`. Добавлена зависимость `coverlet.msbuild` версии `6.0.4` с атрибутами `IncludeAssets` и `PrivateAssets`. Обновлена версия `Microsoft.NET.Test.Sdk` с `17.8.0` до `18.0.0`.